### PR TITLE
Fix Docker env defaults and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# FantasyOne Project
+
+This repository contains a Spring Boot backend and a React frontend served by Nginx.
+
+## Running with Docker Compose
+
+1. Build and start all services:
+   ```bash
+   docker compose up --build
+   ```
+2. Access the application at `http://localhost`.
+
+If the frontend shows a blank page, ensure the `frontend` image was built correctly and that `/usr/share/nginx/html/index.html` exists inside the running container.
+
+Backend and frontend services are configured to restart automatically. Check container logs with `docker compose logs <service>` if they exit unexpectedly.

--- a/backend_fantasyone/src/main/resources/application.properties
+++ b/backend_fantasyone/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=fantasyone
-spring.datasource.url=jdbc:mysql://mysql:3306/fantasyone
-spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/fantasyone}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:root}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:root}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     build:
       context: ./backend_fantasyone
       dockerfile: Dockerfile
+    restart: unless-stopped
     depends_on:
       - db
     environment:
@@ -31,6 +32,7 @@ services:
     build:
       context: ./frontend_react
       dockerfile: Dockerfile
+    restart: unless-stopped
     ports:
       - "80:80"
     depends_on:


### PR DESCRIPTION
## Summary
- add a top-level README with docker instructions
- read datasource information from environment variables
- keep backend and frontend containers running with restart policy

## Testing
- `mvn -q test` *(fails: `mvn` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846c47927ec833190ceff6aaeabba64